### PR TITLE
Adapter now stays alive after a test run has ended

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ The software is distributed under the MIT license, see LICENSE
 
 ## Running the adapter
 ### Prerequisites
-This example adapter is depended on Python (>= 3.10) and uses `pip` for its dependency management. T
-he below steps presume that the `python` and `pip` commands are resolvable in your shell.
+This example adapter is depended on Python (>= 3.10) and uses `pip` for its dependency management. The steps below presume that the `python` and `pip` commands are resolvable in your shell.
 
 ### Setting it up
 - Clone this repository

--- a/src/adapter/generic/adapter_core.py
+++ b/src/adapter/generic/adapter_core.py
@@ -58,6 +58,13 @@ class AdapterCore:
         else:
             logging.info('Connection opened while already connected')
 
+    def on_close(self):
+        """ Connection with AMP has been closed. Try to reconnect. """
+        self.state = State.DISCONNECTED
+        self.handler.stop()
+        logging.info('Trying to reconnect to AMP.')
+        self.start() # reconnect to AMP - keep the adapter alive
+
     def on_configuration(self, pb_config: configuration_pb2.Configuration):
         """
         Broker call back when a `Configuration` message is received from AMP.

--- a/src/adapter/generic/broker_connection.py
+++ b/src/adapter/generic/broker_connection.py
@@ -63,9 +63,9 @@ class BrokerConnection:
             close_status_code (int): The status code returned by closing the connection
             close_msg (str): The reason for the connection termination.
         """
-        logging.info('Stopped connection with code: {code}, with reason: {reason}'
+        logging.info('WebSocket connection has been closed with code: {code}, with reason: {reason}'
                      .format(code=close_status_code, reason=close_msg))
-        self.websocket.close()
+        self.adapter_core.on_close()
 
 
     def on_message(self, message):

--- a/src/adapter/smartdoor/smartdoor_connection.py
+++ b/src/adapter/smartdoor/smartdoor_connection.py
@@ -88,5 +88,8 @@ class SmartDoorConnection:
         """
         if self.websocket:
             self.websocket.close()
-            self.wst.stop()
+            logging.debug('Stopping thread which handles WebSocket connection with SUT')
+            self.websocket.keep_running = False
+            self.wst.join()
+            logging.debug('Thread stopped')
             self.wst = None


### PR DESCRIPTION
* The adapter is kept alive after a test run has ended (and AMP has closed the connection): a new WebSocket connection with AMP is made.
* Added methods label2message and message2label to the SmartDoor handler.